### PR TITLE
Fix native bubbles on Android 11+ and remove the link-open screen flash

### DIFF
--- a/android-app/lynket/src/main/AndroidManifest.xml
+++ b/android-app/lynket/src/main/AndroidManifest.xml
@@ -143,8 +143,10 @@
     <!-- Entry point for browser activity -->
     <activity
       android:name=".browsing.browserintercept.BrowserInterceptActivity"
+      android:excludeFromRecents="true"
       android:exported="true"
       android:label="@string/app_name"
+      android:taskAffinity=""
       android:theme="@style/Theme.AppCompat.Translucent" />
 
     <activity-alias

--- a/android-app/lynket/src/main/java/arun/com/chromer/bubbles/system/BubbleNotificationManager.kt
+++ b/android-app/lynket/src/main/java/arun/com/chromer/bubbles/system/BubbleNotificationManager.kt
@@ -32,6 +32,10 @@ import android.net.Uri
 import android.os.Build
 import android.view.WindowManager
 import androidx.annotation.RequiresApi
+import androidx.core.app.Person as PersonCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.core.graphics.drawable.toBitmap
 import arun.com.chromer.R
 import arun.com.chromer.browsing.webview.EmbeddableWebViewActivity
@@ -43,7 +47,11 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
-private const val BUBBLE_NOTIFICATION_CHANNEL_ID = "BUBBLE_NOTIFICATION_CHANNEL_ID"
+// NOTE: A NotificationChannel's bubble setting is locked at creation time and cannot be
+// changed afterwards. Bumping this id forces a fresh channel created *with*
+// setAllowBubbles(true), so installs that already had the old (bubble-disabled) channel
+// start bubbling. Bump the suffix again if the channel config ever needs to change.
+private const val BUBBLE_NOTIFICATION_CHANNEL_ID = "BUBBLE_NOTIFICATION_CHANNEL_ID_v2"
 private const val BUBBLE_NOTIFICATION_GROUP = "bubbles"
 
 @Singleton
@@ -104,13 +112,20 @@ constructor(
     val context = bubbleData.contextRef.get() ?: application
     val website = bubbleData.website
 
+    val viewIntent = Intent(context, EmbeddableWebViewActivity::class.java).apply {
+      // A non-null action is required so the same Intent can back a sharing shortcut.
+      action = Intent.ACTION_VIEW
+      data = Uri.parse(website.url)
+    }
+
     val bubbleIntent = PendingIntent.getActivity(
       context,
       website.url.hashCode(),
-      Intent(context, EmbeddableWebViewActivity::class.java).apply {
-        data = Uri.parse(website.url)
-      },
-      PendingIntent.FLAG_UPDATE_CURRENT
+      viewIntent,
+      // FLAG_IMMUTABLE is mandatory once targeting Android 12 (targetSdk 31): without
+      // it PendingIntent creation throws IllegalArgumentException and the bubble never
+      // gets built. This is one half of why native bubbles were broken (issue #170).
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
 
     val bubbleIcon: Icon = bubbleData.icon
@@ -120,6 +135,50 @@ constructor(
     val displayHeight = (application.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
       .defaultDisplay
       .let { display -> Point().apply(display::getSize).y }
+    val desiredHeight = Utils.pxToDp((displayHeight * 0.8).toInt())
+
+    // From Android 11 (API 30) a notification only surfaces as a bubble when it
+    // references a *published* long-lived sharing shortcut. Without it the platform
+    // silently downgrades the bubble to an ordinary notification, which is the main
+    // reason native bubbles appeared broken on Android 11+ (issue #170).
+    val shortcutId = website.url
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      val shortcut = ShortcutInfoCompat.Builder(application, shortcutId)
+        .setLongLived(true)
+        .setShortLabel(website.safeLabel())
+        .setLongLabel(website.preferredUrl())
+        .setIcon(bubbleData.bubbleIconCompat())
+        .setIntent(viewIntent)
+        .setPerson(
+          PersonCompat.Builder()
+            .setBot(true)
+            .setName(website.safeLabel())
+            .setImportant(true)
+            .build()
+        )
+        .build()
+      // Must be published before notify(), otherwise the bubble metadata won't apply.
+      ShortcutManagerCompat.pushDynamicShortcut(application, shortcut)
+    }
+
+    val bubbleMetadata = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // Shortcut-backed metadata is the supported path on API 30+.
+      Notification.BubbleMetadata.Builder(shortcutId)
+        .setDesiredHeight(desiredHeight)
+        .setAutoExpandBubble(false)
+        .setSuppressNotification(true)
+        .build()
+    } else {
+      // API 29 (Android 10) only supports the icon + intent constructor.
+      @Suppress("DEPRECATION")
+      Notification.BubbleMetadata.Builder()
+        .setIcon(bubbleIcon)
+        .setIntent(bubbleIntent)
+        .setDesiredHeight(desiredHeight)
+        .setAutoExpandBubble(false)
+        .setSuppressNotification(true)
+        .build()
+    }
 
     val bubbleNotification = notification(context, BUBBLE_NOTIFICATION_CHANNEL_ID) {
       setContentTitle(website.safeLabel())
@@ -136,14 +195,17 @@ constructor(
       setSmallIcon(Icon.createWithResource(context, R.drawable.ic_chromer_notification))
       setLargeIcon(bubbleIcon)
 
-      bubbleMetadata {
-        setIcon(bubbleIcon)
-        setIcon(bubbleIcon)
-        setIntent(bubbleIntent)
-        setAutoExpandBubble(false)
-        setSuppressNotification(true)
-        setDesiredHeight(Utils.pxToDp((displayHeight * 0.8).toInt()))
+      // Fallback when the bubble can't be shown (bubbles disabled for the app/channel):
+      // the notification degrades gracefully and tapping it opens the page instead of
+      // doing nothing.
+      setContentIntent(bubbleIntent)
+
+      // Associating the notification with the published shortcut is what makes it a
+      // valid conversation/bubble on Android 11+.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        setShortcutId(shortcutId)
       }
+      setBubbleMetadata(bubbleMetadata)
 
       // Required when targeting 10
       // https://developer.android.com/guide/topics/ui/bubbles#when_bubbles_appear
@@ -174,5 +236,20 @@ constructor(
   } else {
     Icon.createWithResource(application, R.mipmap.ic_launcher)
   }
+
+  /** [IconCompat] counterpart of [fallbackIcon] used for the sharing shortcut on API 30+. */
+  private fun BubbleLoadData.bubbleIconCompat(): IconCompat = icon
+    ?.let(IconCompat::createWithAdaptiveBitmap)
+    ?: if (color != Constants.NO_COLOR) {
+      val iconSize = application.dpToPx(108.0)
+      IconCompat.createWithAdaptiveBitmap(
+        ColorDrawable(color).toBitmap(
+          width = iconSize,
+          height = iconSize
+        )
+      )
+    } else {
+      IconCompat.createWithResource(application, R.mipmap.ic_launcher)
+    }
 }
 

--- a/android-app/lynket/src/main/res/values/styles.xml
+++ b/android-app/lynket/src/main/res/values/styles.xml
@@ -106,7 +106,23 @@
 
   <style name="AppTheme.Launcher" parent="Theme.AppCompat.Light.NoActionBar" />
 
-  <style name="Theme.AppCompat.Translucent" parent="Theme.AppCompat.NoActionBar" />
+  <!--
+    Invisible "trampoline" theme used by link interceptors (BrowserInterceptActivity,
+    CustomTabActivity, OpenWith). It was previously translucent in name only, so these
+    activities flashed an opaque full-screen window when launched from another app
+    (e.g. opening a link from Telegram showed a visible switch-away-and-back before the
+    bubble appeared). Making it genuinely transparent, dropping the launch-preview window
+    and disabling enter/exit animations lets the interceptor do its work invisibly.
+  -->
+  <style name="Theme.AppCompat.Translucent" parent="Theme.AppCompat.NoActionBar">
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:backgroundDimEnabled">false</item>
+    <item name="android:windowAnimationStyle">@null</item>
+    <item name="android:windowDisablePreview">true</item>
+  </style>
 
   <style name="Preference_TextAppearanceMaterialBody2">
     <item name="android:textSize">14sp</item>


### PR DESCRIPTION
## Summary

Two independent fixes for the native (system) **Bubbles** feature:

1. **Native bubbles never appear on Android 11+** (#170) — they silently fall back to a regular notification.
2. **Opening a link from another app flashes an opaque screen** (a visible "switch away and back") before the bubble shows.

The two fixes are independent and touch disjoint files, so they are kept as **two separate commits**.

---

## Fix 1 — Native bubbles on Android 11+ (`BubbleNotificationManager`)

Root causes:

- **No sharing shortcut.** From API 30, a notification only surfaces as a bubble when it references a *published* long-lived shortcut. The code published none, so the platform downgraded the bubble to an ordinary notification.
- **`PendingIntent` without `FLAG_IMMUTABLE`.** On Android 12 (targetSdk 31) creating a `PendingIntent` without `FLAG_IMMUTABLE`/`FLAG_MUTABLE` throws `IllegalArgumentException`, aborting bubble creation.
- **No `contentIntent`.** When the notification falls back (bubbles disabled), tapping it did nothing.
- **Stale channel.** A `NotificationChannel`'s bubble flag is immutable after creation, so a channel created without `setAllowBubbles(true)` can never bubble.

Changes:

- Build and `pushDynamicShortcut` a `ShortcutInfoCompat` per URL, set it via `setShortcutId`, and use the shortcut-backed `BubbleMetadata.Builder(shortcutId)` on API 30+ (API 29 keeps the legacy icon + intent metadata).
- Add `FLAG_IMMUTABLE` to the bubble `PendingIntent`.
- Add `setContentIntent` so the fallback notification opens the page.
- Bump the notification channel id so a fresh, bubble-enabled channel is created.

## Fix 2 — Link interceptor flash (`styles.xml`, `AndroidManifest.xml`)

The link trampoline activities use `Theme.AppCompat.Translucent`, which — despite its name — was a plain opaque `NoActionBar` theme. So `BrowserInterceptActivity` flashed a full-screen opaque window (plus a launch-preview window and transition animations) every time a link was opened from another app.

Changes:

- Make the theme genuinely transparent: `windowIsTranslucent`, transparent `windowBackground`, `windowDisablePreview`, and no window animations. This also removes the same flash for `CustomTabActivity` and the OpenWith trampoline.
- Give `BrowserInterceptActivity` `excludeFromRecents` + empty `taskAffinity` so the trampoline leaves no recents entry and returns cleanly to the caller.

---

## How it was tested

Built a debug APK and tested on a physical **Pixel 8 Pro (Android 17 / SDK 37)** via `adb`:

- **Bubbles now work.** With the fix and the app's Bubble permission granted, `dumpsys notification` reports the notification's shortcut as `found valid? true`, `mAllowBubble=true`, `isBubble=true`, and the window manager creates a `Bubbles!` window. The bubble appears and expands to the page.
- **The bug is real, not just a permission issue.** Built the *original, unpatched* code at targetSdk 31 and confirmed that — even with the Bubble permission explicitly granted — opening a link throws `IllegalArgumentException: Targeting S+ requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified` and no bubble is posted. So the fix addresses a genuine code defect independent of user settings.
- **Flash is gone.** The interceptor no longer shows an opaque window when opening a link from another app; only the bubble appears.

Note: the app-level Bubble permission is user-controlled and cannot be set programmatically. Users still need to allow bubbles for the app (Settings → Apps → Lynket → Notifications → Bubbles).

## Notes for the reviewer

- **No automated tests in this PR.** The test source set does not currently compile (`TestAppModule extends AppModule`, and Dagger 2.42 does not inherit `@Provides` from a superclass module, so `TestAppComponent` is missing an `Application` binding), and Robolectric is pinned at 4.3, which cannot simulate API 30+ (where this fix is exercised). I'm happy to add Robolectric coverage (`@Config(sdk = [31])` asserting the published shortcut, `shortcutId`, immutable `PendingIntent`, and `BubbleMetadata`) once the test infrastructure can build and run.
- **Building from a clean checkout currently fails for unrelated reasons** — `:lynket`/`:disk-cache` are commented out in `settings.gradle`, `build-logic`'s `dependencies {}` block is commented out, and several dependencies point to now-defunct repositories. These fixes were verified by re-enabling the modules locally; that build plumbing is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
